### PR TITLE
Improve quick-add parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native-stack": "^7.3.14",
         "@react-navigation/stack": "^7.3.3",
         "@reduxjs/toolkit": "^2.8.2",
+        "chrono-node": "^2.8.2",
         "expo": "~52.0.0",
         "expo-blur": "~14.0.3",
         "expo-build-properties": "~0.13.3",
@@ -5581,6 +5582,18 @@
         "rimraf": "^3.0.2"
       }
     },
+    "node_modules/chrono-node": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.2.tgz",
+      "integrity": "sha512-7BJ6TRHs4sFtOSsTISWXGKjg7C70wD+NU+44uA6euGnbvZnECvgzUv+5TS9sICta2sBQWej4UYy8XAg4W9E7rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.10.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -5967,6 +5980,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native-stack": "^7.3.14",
     "@react-navigation/stack": "^7.3.3",
     "@reduxjs/toolkit": "^2.8.2",
+    "chrono-node": "^2.8.2",
     "expo": "~52.0.0",
     "expo-blur": "~14.0.3",
     "expo-build-properties": "~0.13.3",


### PR DESCRIPTION
## Summary
- add `chrono-node` for natural language date parsing
- parse reminders and use chrono to set due date
- open project/label pickers when `#` or `@` typed

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module './locales/en.json' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684942dc2b388333adfaec36fc0fdbda